### PR TITLE
Add more JsonMerger logic

### DIFF
--- a/src/main/java/com/jeff_media/resourcepackmerger/mergers/JsonMerger.java
+++ b/src/main/java/com/jeff_media/resourcepackmerger/mergers/JsonMerger.java
@@ -67,8 +67,8 @@ public class JsonMerger {
                     ArrayList arr = new ArrayList((ArrayList) entry.getValue());
                     arr.add(newMap.get(entry.getKey()));
                     map.put(entry.getKey(), arr);
-                } else if(entry.getKey().equals("pack_format")){
-                    map.put(entry.getKey(), new ArrayList(List.of(newMap.get(entry.getKey()), entry.getValue()))); //gets replaced elsewhere but why not
+                } else if(entry.getKey().equals("supported_formats")){
+                    map.put(entry.getKey(), new ArrayList(List.of(newMap.get(entry.getKey()), entry.getValue())));
                 } else if(entry.getValue() instanceof String && newMap.get(entry.getKey()) instanceof String){
                     String strOld = (String) entry.getValue();
                     String strNew = (String) newMap.get(entry.getKey());

--- a/src/main/java/com/jeff_media/resourcepackmerger/mergers/JsonMerger.java
+++ b/src/main/java/com/jeff_media/resourcepackmerger/mergers/JsonMerger.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -43,6 +44,8 @@ public class JsonMerger {
         return PrettyObjectMapper.get().writeValueAsString(map);
     }
 
+    private static final HashSet<String> MERGEABLE_ARRAY_KEYS = new HashSet<String>(List.of("overrides", "sources", "supported_formats"));
+
     private static Map<String,Object> mergeMaps(Map<String, Object> oldMap, Map<String, Object> newMap) {
         Map<String,Object> map = new HashMap<>(newMap);
         for(Map.Entry<String,Object> entry : oldMap.entrySet()) {
@@ -52,7 +55,7 @@ public class JsonMerger {
                 if(entry.getValue() instanceof Map && newMap.get(entry.getKey()) instanceof Map) {
                     map.put(entry.getKey(), mergeMaps((Map<String, Object>) oldMap.get(entry.getKey()), (Map<String, Object>) newMap.get(entry.getKey())));
                 } 
-                else if (newMap.get(entry.getKey()) instanceof ArrayList){
+                else if (newMap.get(entry.getKey()) instanceof ArrayList && MERGEABLE_ARRAY_KEYS.contains(entry.getKey())){
                     ArrayList arr = new ArrayList((ArrayList) newMap.get(entry.getKey()));
                     if (entry.getValue() instanceof ArrayList) {
                         arr.addAll((ArrayList) entry.getValue());
@@ -60,7 +63,7 @@ public class JsonMerger {
                         arr.add(entry.getValue());
                     }
                     map.put(entry.getKey(), arr);
-                } else if(entry.getValue() instanceof ArrayList){
+                } else if(entry.getValue() instanceof ArrayList && MERGEABLE_ARRAY_KEYS.contains(entry.getKey())){
                     ArrayList arr = new ArrayList((ArrayList) entry.getValue());
                     arr.add(newMap.get(entry.getKey()));
                     map.put(entry.getKey(), arr);

--- a/src/main/java/com/jeff_media/resourcepackmerger/mergers/McMetaMerger.java
+++ b/src/main/java/com/jeff_media/resourcepackmerger/mergers/McMetaMerger.java
@@ -6,6 +6,8 @@ import com.jeff_media.resourcepackmerger.data.ResourcePackVersion;
 
 import java.io.*;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.Map;
 
 public class McMetaMerger {
@@ -23,6 +25,12 @@ public class McMetaMerger {
             }
             pack.put("description", description);
             pack.put("pack_format", version.getFormat());
+            LinkedHashSet supportedFormats = new LinkedHashSet();
+            if (pack.containsKey("supported_formats")) {
+                supportedFormats.addAll((ArrayList) pack.get("supported_formats"));
+            }
+            supportedFormats.add(version.getFormat());
+            pack.put("supported_formats", new ArrayList(supportedFormats));
             map.put("pack", pack);
             String json = PrettyObjectMapper.get().writeValueAsString(map);
             try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {


### PR DESCRIPTION
I mostly added logic for merging the presence of JSON arrays like model overrides. Sorry for the additional warnings; I saw some unchecked cast warnings when I started, so I took the path of least resistance since my Java understanding is very rusty.

I also added warnings in the logger for unmergeable conflicts instead of only silently picking. I added enough checks that I don't get those warnings for my use case, but that's doubtlessly not exhaustive. Though I would think it's probably a fairly representative use case for those that would be using the JSON merging stuff.